### PR TITLE
Add a Coprime method

### DIFF
--- a/num.go
+++ b/num.go
@@ -1121,7 +1121,32 @@ func (z *Nat) eGCD(x []Word, m []Word) ([]Word, []Word) {
 		ctCondCopy(aEven, u, u2)
 	}
 
-	return a, v
+	return b, v
+}
+
+// Coprime returns 1 if gcd(x, y) == 1, and 0 otherwise
+func (x *Nat) Coprime(y *Nat) int {
+	size := len(x.limbs)
+	if len(y.limbs) > size {
+		size = len(y.limbs)
+	}
+	a := x.resizedLimbs(size)
+	b := y.resizedLimbs(size)
+
+	// Our gcd(a, b) routine requires b to be odd, and will return garbage otherwise.
+	aOdd := choice(a[0] & 1)
+	ctCondSwap(aOdd, a, b)
+
+	scratch := new(Nat)
+	d, _ := scratch.eGCD(a, b)
+
+	scratch.SetUint64(1)
+	one := scratch.resizedLimbs(len(d))
+
+	bOdd := choice(b[0] & 1)
+	// If at least one of a or b is odd, then our GCD calculation will have been correct,
+	// otherwise, both are even, so we want to return false anyways.
+	return int((aOdd | bOdd) & cmpEq(d, one))
 }
 
 // modInverse calculates the inverse of a reduced x modulo m

--- a/num_test.go
+++ b/num_test.go
@@ -729,3 +729,34 @@ func TestDivExamples(t *testing.T) {
 		t.Errorf("%+v != %+v", x, actualNat)
 	}
 }
+
+func TestCoprimeExamples(t *testing.T) {
+	x := new(Nat).SetUint64(5 * 7 * 13)
+	y := new(Nat).SetUint64(3 * 7 * 11)
+	expected := 0
+	actual := x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+	x.SetUint64(2)
+	y.SetUint64(13)
+	expected = 1
+	actual = x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+	x.SetUint64(13)
+	y.SetUint64(2)
+	expected = 1
+	actual = x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+	x.SetUint64(2 * 13 * 11)
+	y.SetUint64(2 * 5 * 7)
+	expected = 0
+	actual = x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes #3.

GCD would be pretty easy to calculate, except in the case where both integers are even. All you really need for most applications is knowing whether or not two integers are coprime, so this is simpler, but still sufficient.