### PR TITLE
Implement TrueSize in a less leaky way

### DIFF
--- a/num.go
+++ b/num.go
@@ -191,8 +191,7 @@ func (z *Nat) AnnouncedLen() uint {
 
 // leadingZeros calculates the number of leading zero bits in x.
 //
-// This should be less leaky than bits.LeadingZeros, leaking only the number
-// of zero bits, but not other information about the value of x.
+// This shouldn't leak any information about the value of x.
 func leadingZeros(x Word) uint {
 	stillZero := choice(1)
 	leadingZeroBytes := Word(0)
@@ -211,7 +210,7 @@ func leadingZeros(x Word) uint {
 			leadingZeroBits += Word(stillZero)
 		}
 	}
-	return uint(leadingZeroBytes + leadingZeroBits)
+	return uint(8*leadingZeroBytes + leadingZeroBits)
 }
 
 // TrueLen calculates the exact number of bits needed to represent z

--- a/num.go
+++ b/num.go
@@ -174,10 +174,12 @@ func (z *Nat) unaliasedLimbs(x *Nat) []Word {
 // trueSize calculates the actual size necessary for representing these limbs
 //
 // This is the size with leading zeros removed. This leaks the number
-// of such zeros
+// of such zeros, but nothing else.
 func trueSize(limbs []Word) uint {
 	var size uint
-	for size = uint(len(limbs)); size > 0 && limbs[size-1] == 0; size-- {
+	// Instead of checking == 0 directly, which may leak the value, we instead
+	// compare with zero in constant time, and check if that succeeded in a leaky way.
+	for size = uint(len(limbs)); size > 0 && ctEq(limbs[size-1], 0) == 1; size-- {
 	}
 	return size
 }

--- a/num_test.go
+++ b/num_test.go
@@ -788,3 +788,18 @@ func TestCoprimeExamples(t *testing.T) {
 		t.Errorf("%+v != %+v", expected, actual)
 	}
 }
+
+func TestTrueLenExamples(t *testing.T) {
+	x := new(Nat).SetUint64(0x0000_0000_0000_0001)
+	expected := uint(1)
+	actual := x.TrueLen()
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+	x.SetUint64(0x0000_0000_0100_0001)
+	expected = uint(25)
+	actual = x.TrueLen()
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes #8.

Now this should only leak the number of leading zero limbs in the number. But, it shouldn't leak the value of the first non-zero limb. This was a potential concern with the previous way of doing things. We also now have stronger guarantees, instead of having TrueSize leak the value completely.