### PR TITLE
Make announced size a precise number of bits

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -15,5 +15,5 @@ func limbMask(bits int) Word {
 	if remaining == 0 {
 		return allOnes
 	}
-	return 1 ^ (allOnes << remaining)
+	return ^(allOnes << remaining)
 }

--- a/bits.go
+++ b/bits.go
@@ -4,3 +4,16 @@ package safenum
 func limbCountFromBits(bits int) int {
 	return (bits + _W - 1) / _W
 }
+
+// limbMask returns the mask used for the final limb of a Nat with this number of bits.
+//
+// Note that this function will leak the number of bits. For our library, this isn't
+// a problem, since we always call this function with announced sizes.
+func limbMask(bits int) Word {
+	remaining := bits % _W
+	allOnes := ^Word(0)
+	if remaining == 0 {
+		return allOnes
+	}
+	return 1 ^ (allOnes << remaining)
+}

--- a/bits.go
+++ b/bits.go
@@ -1,0 +1,6 @@
+package safenum
+
+// limbCountFromBits returns the number of limbs needed to accomodate bits.
+func limbCountFromBits(bits int) int {
+	return (bits + _W - 1) / _W
+}

--- a/bits.go
+++ b/bits.go
@@ -1,7 +1,7 @@
 package safenum
 
-// limbCountFromBits returns the number of limbs needed to accomodate bits.
-func limbCountFromBits(bits int) int {
+// limbCount returns the number of limbs needed to accomodate bits.
+func limbCount(bits int) int {
 	return (bits + _W - 1) / _W
 }
 

--- a/bits_test.go
+++ b/bits_test.go
@@ -1,0 +1,15 @@
+package safenum
+
+import (
+	"math/rand"
+	"testing"
+)
+
+var result Word
+
+func BenchmarkLimbMask(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := rand.Int()
+		result = limbMask(x)
+	}
+}

--- a/num.go
+++ b/num.go
@@ -179,6 +179,25 @@ type Nat struct {
 	limbs []Word
 }
 
+// checkInvariants does some internal sanity checks.
+//
+// This is useful for tests.
+func (z *Nat) checkInvariants() bool {
+	if z.reduced != nil && z.announced != z.reduced.nat.announced {
+		return false
+	}
+	if len(z.limbs) != limbCount(z.announced) {
+		return false
+	}
+	if len(z.limbs) > 0 {
+		lastLimb := z.limbs[len(z.limbs)-1]
+		if lastLimb != lastLimb&limbMask(z.announced) {
+			return false
+		}
+	}
+	return true
+}
+
 // ensureLimbCapacity makes sure that a Nat has capacity for a certain number of limbs
 //
 // This will modify the slice contained inside the natural, but won't change the size of

--- a/num.go
+++ b/num.go
@@ -1210,12 +1210,12 @@ func (z *Nat) eGCD(x []Word, m []Word) ([]Word, []Word) {
 
 // Coprime returns 1 if gcd(x, y) == 1, and 0 otherwise
 func (x *Nat) Coprime(y *Nat) Choice {
-	size := len(x.limbs)
-	if len(y.limbs) > size {
-		size = len(y.limbs)
+	maxBits := x.announced
+	if y.announced > maxBits {
+		maxBits = y.announced
 	}
-	a := x.resizedLimbs(size)
-	b := y.resizedLimbs(size)
+	a := x.resizedLimbs(maxBits)
+	b := y.resizedLimbs(maxBits)
 
 	// Our gcd(a, b) routine requires b to be odd, and will return garbage otherwise.
 	aOdd := Choice(a[0] & 1)
@@ -1225,7 +1225,7 @@ func (x *Nat) Coprime(y *Nat) Choice {
 	d, _ := scratch.eGCD(a, b)
 
 	scratch.SetUint64(1)
-	one := scratch.resizedLimbs(len(d))
+	one := scratch.resizedLimbs(maxBits)
 
 	bOdd := Choice(b[0] & 1)
 	// If at least one of a or b is odd, then our GCD calculation will have been correct,

--- a/num.go
+++ b/num.go
@@ -154,10 +154,28 @@ func mulSubVVW(z, x []Word, y Word) (c Word) {
 // The capacity of a number is usually inherited through whatever method was used to
 // create the number in the first place.
 type Nat struct {
-	// Two natural numbers are not allowed to share the same slice. This allows
-	// us to use pointer comparison to check that Nats don't alias eachother
-	limbs   []Word
+	// The exact number of bits this number claims to have.
+	//
+	// This can differ from the actual number of bits needed to represent this number.
+	announced int
+	// If this is set, then the value of this Nat is in the range 0..reduced - 1.
+	//
+	// This value should get set based only on statically knowable things, like what
+	// functions have been called. This means that we will have plenty of false
+	// negatives, where a value is small enough, but we don't know statically
+	// that this is the case.
+	//
+	// Invariant: If reduced is set, then announced should match the announced size of
+	// this modulus.
 	reduced *Modulus
+	// The limbs representing this number, in little endian order.
+	//
+	// Invariant: The bits past announced will not be set. This includes when announced
+	// isn't a multiple of the limb size.
+	//
+	// Invariant: two Nats are not allowed to share the same slice.
+	// This allows us to use pointer comparison to check that Nats don't alias eachother
+	limbs []Word
 }
 
 // ensureLimbCapacity makes sure that a Nat has capacity for a certain number of limbs

--- a/num.go
+++ b/num.go
@@ -87,10 +87,7 @@ func ctCondSwap(v Choice, a, b []Word) {
 //
 // The announced size of the result will be the largest size between z and x.
 func (z *Nat) CondAssign(yes Choice, x *Nat) *Nat {
-	maxBits := x.announced
-	if z.announced > maxBits {
-		maxBits = z.announced
-	}
+	maxBits := z.maxAnnounced(x)
 
 	xLimbs := x.resizedLimbs(maxBits)
 	z.limbs = z.resizedLimbs(maxBits)
@@ -200,6 +197,15 @@ func (z *Nat) checkInvariants() bool {
 		}
 	}
 	return true
+}
+
+// maxAnnounced returns the larger announced length of z and y
+func (z *Nat) maxAnnounced(y *Nat) int {
+	maxBits := z.announced
+	if y.announced > maxBits {
+		maxBits = y.announced
+	}
+	return maxBits
 }
 
 // ensureLimbCapacity makes sure that a Nat has capacity for a certain number of limbs
@@ -1082,10 +1088,7 @@ func (z *Nat) Cmp(x *Nat) (Choice, Choice, Choice) {
 	// Rough Idea: Resize both slices to the maximum length, then compare
 	// using that length
 
-	maxBits := x.announced
-	if z.announced > maxBits {
-		maxBits = z.announced
-	}
+	maxBits := z.maxAnnounced(x)
 	zLimbs := z.resizedLimbs(maxBits)
 	xLimbs := x.resizedLimbs(maxBits)
 
@@ -1210,10 +1213,7 @@ func (z *Nat) eGCD(x []Word, m []Word) ([]Word, []Word) {
 
 // Coprime returns 1 if gcd(x, y) == 1, and 0 otherwise
 func (x *Nat) Coprime(y *Nat) Choice {
-	maxBits := x.announced
-	if y.announced > maxBits {
-		maxBits = y.announced
-	}
+	maxBits := x.maxAnnounced(y)
 	a := x.resizedLimbs(maxBits)
 	b := y.resizedLimbs(maxBits)
 

--- a/num.go
+++ b/num.go
@@ -674,8 +674,12 @@ func (z *Nat) Mod(x *Nat, m *Modulus) *Nat {
 // we can achieve the same speed as the Mod method. This wouldn't be the case for
 // an arbitrary Nat.
 //
-// cap determines the number of bits to keep in the result.
+// cap determines the number of bits to keep in the result. If cap < 0, then
+// the number of bits will be x.AnnouncedLen() - m.BitLen() + 2
 func (z *Nat) Div(x *Nat, m *Modulus, cap int) *Nat {
+	if cap < 0 {
+		cap = x.announced - m.nat.announced + 2
+	}
 	if len(x.limbs) < len(m.nat.limbs) || x.reduced == m {
 		z.limbs = z.resizedLimbs(cap)
 		for i := 0; i < len(z.limbs); i++ {
@@ -823,7 +827,12 @@ func (z *Nat) ModNeg(x *Nat, m *Modulus) *Nat {
 // Add calculates z <- x + y, modulo 2^cap
 //
 // The capacity is given in bits, and also controls the size of the result.
+//
+// If cap < 0, the capacity will be max(x.AnnouncedLen(), y.AnnouncedLen()) + 1
 func (z *Nat) Add(x *Nat, y *Nat, cap int) *Nat {
+	if cap < 0 {
+		cap = x.maxAnnounced(y) + 1
+	}
 	xLimbs := x.resizedLimbs(cap)
 	yLimbs := y.resizedLimbs(cap)
 	z.limbs = z.resizedLimbs(cap)
@@ -838,7 +847,12 @@ func (z *Nat) Add(x *Nat, y *Nat, cap int) *Nat {
 // Sub calculates z <- x - y, modulo 2^cap
 //
 // The capacity is given in bits, and also controls the size of the result.
+//
+// If cap < 0, the capacity will be max(x.AnnouncedLen(), y.AnnouncedLen())
 func (z *Nat) Sub(x *Nat, y *Nat, cap int) *Nat {
+	if cap < 0 {
+		cap = x.maxAnnounced(y)
+	}
 	xLimbs := x.resizedLimbs(cap)
 	yLimbs := y.resizedLimbs(cap)
 	z.limbs = z.resizedLimbs(cap)
@@ -942,7 +956,12 @@ func (z *Nat) ModMul(x *Nat, y *Nat, m *Modulus) *Nat {
 // Mul calculates z <- x * y, modulo 2^cap
 //
 // The capacity is given in bits, and also controls the size of the result.
+//
+// If cap < 0, the capacity will be x.AnnouncedLen() + y.AnnouncedLen()
 func (z *Nat) Mul(x *Nat, y *Nat, cap int) *Nat {
+	if cap < 0 {
+		cap = x.announced + y.announced
+	}
 	size := limbCount(cap)
 	// Since we neex to set z to zero, we have no choice to use a new buffer,
 	// because we allow z to alias either of the arguments

--- a/num.go
+++ b/num.go
@@ -32,7 +32,7 @@ func ctEq(x, y Word) Choice {
 	// For any q != 0, either the MSB of q, or the MSB of -q is 1.
 	// We can thus or those together, and check the top bit. When q is zero,
 	// that means that x and y are equal, so we negate that top bit.
-	return 1 ^ Choice((q|-q)>>63)
+	return 1 ^ Choice((q|-q)>>(_W-1))
 }
 
 // ctGt checks x > y, returning 1 or 0

--- a/num_test.go
+++ b/num_test.go
@@ -65,6 +65,19 @@ func TestByteVsBytes(t *testing.T) {
 	}
 }
 
+func testSetBytesRoundTrip(expected []byte) bool {
+	x := new(Nat).SetBytes(expected)
+	actual := x.Bytes()
+	return bytes.Equal(expected, actual)
+}
+
+func TestSetBytesRoundTrip(t *testing.T) {
+	err := quick.Check(testSetBytesRoundTrip, &quick.Config{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func testAddZeroIdentity(n Nat) bool {
 	if !n.checkInvariants() {
 		return false

--- a/num_test.go
+++ b/num_test.go
@@ -2,6 +2,7 @@ package safenum
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -246,9 +247,13 @@ func TestModAddAssociative(t *testing.T) {
 }
 
 func testModAddModSubInverse(a Nat, b Nat, m Modulus) bool {
+	fmt.Println("a", a, "b", b)
 	var c Nat
+	fmt.Println("c1", c)
 	c.ModAdd(&a, &b, &m)
+	fmt.Println("c2", c)
 	c.ModSub(&c, &b, &m)
+	fmt.Println("c3", c)
 	expected := new(Nat)
 	expected.Mod(&a, &m)
 	return c.Eq(expected) == 1
@@ -806,28 +811,28 @@ func TestDivExamples(t *testing.T) {
 func TestCoprimeExamples(t *testing.T) {
 	x := new(Nat).SetUint64(5 * 7 * 13)
 	y := new(Nat).SetUint64(3 * 7 * 11)
-	expected := 0
+	expected := Choice(0)
 	actual := x.Coprime(y)
 	if expected != actual {
 		t.Errorf("%+v != %+v", expected, actual)
 	}
 	x.SetUint64(2)
 	y.SetUint64(13)
-	expected = 1
+	expected = Choice(1)
 	actual = x.Coprime(y)
 	if expected != actual {
 		t.Errorf("%+v != %+v", expected, actual)
 	}
 	x.SetUint64(13)
 	y.SetUint64(2)
-	expected = 1
+	expected = Choice(1)
 	actual = x.Coprime(y)
 	if expected != actual {
 		t.Errorf("%+v != %+v", expected, actual)
 	}
 	x.SetUint64(2 * 13 * 11)
 	y.SetUint64(2 * 5 * 7)
-	expected = 0
+	expected = Choice(0)
 	actual = x.Coprime(y)
 	if expected != actual {
 		t.Errorf("%+v != %+v", expected, actual)

--- a/num_test.go
+++ b/num_test.go
@@ -2,7 +2,6 @@ package safenum
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -247,13 +246,9 @@ func TestModAddAssociative(t *testing.T) {
 }
 
 func testModAddModSubInverse(a Nat, b Nat, m Modulus) bool {
-	fmt.Println("a", a, "b", b)
 	var c Nat
-	fmt.Println("c1", c)
 	c.ModAdd(&a, &b, &m)
-	fmt.Println("c2", c)
 	c.ModSub(&c, &b, &m)
-	fmt.Println("c3", c)
 	expected := new(Nat)
 	expected.Mod(&a, &m)
 	return c.Eq(expected) == 1

--- a/num_test.go
+++ b/num_test.go
@@ -465,11 +465,11 @@ func testModInverseEvenMinusOne(a Nat) bool {
 	var one Nat
 	one.SetUint64(1)
 	var z Nat
-	z.Add(&a, &one, len(a.limbs)*_W+1)
+	z.Add(&a, &one, a.AnnouncedLen()+1)
 	if !z.checkInvariants() {
 		return false
 	}
-	z2 := new(Nat).modInverseEven(&a, ModulusFromNat(&z))
+	z2 := new(Nat).ModInverse(&a, ModulusFromNat(&z))
 	if !z2.checkInvariants() {
 		return false
 	}

--- a/num_test.go
+++ b/num_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (Nat) Generate(r *rand.Rand, size int) reflect.Value {
-	bytes := make([]byte, 1)
+	bytes := make([]byte, 16*_S)
 	r.Read(bytes)
 	var n Nat
 	n.SetBytes(bytes)
@@ -18,7 +18,7 @@ func (Nat) Generate(r *rand.Rand, size int) reflect.Value {
 }
 
 func (Modulus) Generate(r *rand.Rand, size int) reflect.Value {
-	bytes := make([]byte, 1)
+	bytes := make([]byte, 8*_S)
 	r.Read(bytes)
 	// Ensure that our number isn't 0, but being even is ok
 	bytes[len(bytes)-1] |= 0b10


### PR DESCRIPTION
Fixes #14.

This will be very useful for unbounded calculations, since it avoids bit explosion. This also adds support for omitting the bound passed to an operation, using a smart default instead.