### PR TITLE
Add clone methods for Int and Nat

### DIFF
--- a/int.go
+++ b/int.go
@@ -49,6 +49,16 @@ func (z *Int) SetNat(x *Nat) *Int {
 	return z
 }
 
+// Clone returns a copy of this Int.
+//
+// The copy can safely be mutated without affecting the original value.
+func (z *Int) Clone() *Int {
+	out := new(Int)
+	out.sign = z.sign
+	out.abs.SetNat(&z.abs)
+	return out
+}
+
 // SetBig will set the value of this number to the value of a big.Int, including sign.
 //
 // The size dicates the number of bits to use for the absolute value. This is important,

--- a/num.go
+++ b/num.go
@@ -540,6 +540,13 @@ func (z *Nat) SetNat(x *Nat) *Nat {
 	return z
 }
 
+// Clone returns a copy of this value.
+//
+// This copy can safely be mutated without affecting the original.
+func (z *Nat) Clone() *Nat {
+	return new(Nat).SetNat(z)
+}
+
 // Resize resizes z to a certain number of bits, returning z.
 func (z *Nat) Resize(cap int) *Nat {
 	z.limbs = z.resizedLimbs(cap)


### PR DESCRIPTION
Fixes #36.

Note that it's not necessary to add such a method for Modulus, since they're immutable, so there's no reason to ever clone one.