### PR TITLE
Implement encoding.Binary{Marshaler, Unmarshaler}

### DIFF
--- a/num.go
+++ b/num.go
@@ -377,6 +377,19 @@ func (z *Nat) Bytes() []byte {
 	return z.FillBytes(out)
 }
 
+// MarshalBinary implements encoding.BinaryMarshaler.
+// Returns the same value as Bytes().
+func (i *Nat) MarshalBinary() ([]byte, error) {
+	return i.Bytes(), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+// Wraps SetBytes
+func (i *Nat) UnmarshalBinary(data []byte) error {
+	i.SetBytes(data)
+	return nil
+}
+
 // convert a 4 bit value into an ASCII value in constant time
 func nibbletoASCII(nibble byte) byte {
 	w := Word(nibble)
@@ -663,6 +676,18 @@ func (m *Modulus) Nat() *Nat {
 // Bytes returns the big endian bytes making up the modulus
 func (m *Modulus) Bytes() []byte {
 	return m.nat.Bytes()
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (i *Modulus) MarshalBinary() ([]byte, error) {
+	return i.nat.Bytes(), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (i *Modulus) UnmarshalBinary(data []byte) error {
+	i.nat.SetBytes(data)
+	i.precomputeValues()
+	return nil
 }
 
 // Big returns the value of this Modulus as a big.Int

--- a/num_test.go
+++ b/num_test.go
@@ -79,6 +79,47 @@ func TestSetBytesRoundTrip(t *testing.T) {
 	}
 }
 
+func testNatMarshalBinaryRoundTrip(x Nat) bool {
+	out, err := x.MarshalBinary()
+	if err != nil {
+		return false
+	}
+	y := new(Nat)
+	err = y.UnmarshalBinary(out)
+	if err != nil {
+		return false
+	}
+	return x.Eq(y) == 1
+}
+
+func TestNatMarshalBinaryRoundTrip(t *testing.T) {
+	err := quick.Check(testNatMarshalBinaryRoundTrip, &quick.Config{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testModulusMarshalBinaryRoundTrip(x Modulus) bool {
+	out, err := x.MarshalBinary()
+	if err != nil {
+		return false
+	}
+	y := new(Modulus)
+	err = y.UnmarshalBinary(out)
+	if err != nil {
+		return false
+	}
+	_, eq, _ := x.Cmp(y)
+	return eq == 1
+}
+
+func TestModulusMarshalBinaryRoundTrip(t *testing.T) {
+	err := quick.Check(testModulusMarshalBinaryRoundTrip, &quick.Config{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func testAddZeroIdentity(n Nat) bool {
 	if !n.checkInvariants() {
 		return false


### PR DESCRIPTION
These functions are simple wrappers around `Nat.SetBytes()` and `Nat.Bytes()`.

For `Modulus`, we additionally call `precomputeValues()` in `UnmarshalBinary()`.

`Int` returns `byte(i.sign) || i.nat.Bytes()`, so that the result is always at least one byte long. Only the LSB of of the first byte is actually used.

Also includes test to check that `MarshalBinary() -> UnmarshalBinary()` returns the same result.