### PR TITLE
Fix `Nat.Rsh` and make test more robust.

### DIFF
--- a/int_test.go
+++ b/int_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (*Int) Generate(r *rand.Rand, size int) reflect.Value {
-	bytes := make([]byte, 16*_S)
+	bytes := make([]byte, r.Int()&127)
 	r.Read(bytes)
 	i := new(Int).SetBytes(bytes)
 	if r.Int()&1 == 1 {

--- a/num.go
+++ b/num.go
@@ -1171,6 +1171,7 @@ func (z *Nat) Rsh(x *Nat, shift uint, cap int) *Nat {
 		}
 	}
 
+	z.limbs = zLimbs
 	z.limbs = z.resizedLimbs(cap)
 	z.announced = cap
 	z.reduced = nil

--- a/num_test.go
+++ b/num_test.go
@@ -262,6 +262,30 @@ func testLshRshRoundTrip(x Nat, s uint8) bool {
 	return x.Eq(z) == 1
 }
 
+func TestRshLshRoundTrip(t *testing.T) {
+	err := quick.Check(testRshLshRoundTrip, &quick.Config{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testRshLshRoundTrip(x Nat, s uint8) bool {
+	if t := x.TrueLen(); int(s) > t {
+		s = uint8(t)
+	}
+	singleShift := s % _W
+	limbShifts := (s - singleShift) / _W
+	i := 0
+	for ; i < int(limbShifts) && i < len(x.limbs)-1; i++ {
+		x.limbs[i] = 0
+	}
+	mask := limbMask(int(singleShift))
+	x.limbs[i] &= ^mask
+	z := new(Nat).Rsh(&x, uint(s), -1)
+	z.Lsh(z, uint(s), -1)
+	return x.Eq(z) == 1
+}
+
 func TestLshRshRoundTrip(t *testing.T) {
 	err := quick.Check(testLshRshRoundTrip, &quick.Config{})
 	if err != nil {


### PR DESCRIPTION
- Setting `x := new(Nat).Rsh(y, s, -1)` would result in `x` not being updated.
- Added a test that would catch this, and tests the inverse round-trip with `Lsh`.
- Use the random generator to determine the size of the numbers generated for the `quick` tests. We ensure they are less than 128 bytes.
- Fixed some edge cases in tests that assumed that the `len(x.limbs) > 0`.