### PR TITLE
Fix #43

### DIFF
--- a/num.go
+++ b/num.go
@@ -1470,7 +1470,8 @@ func (x *Nat) Coprime(y *Nat) Choice {
 	maxBits := x.maxAnnounced(y)
 	size := limbCount(maxBits)
 	if size == 0 {
-		// technically the result
+		// technically the result should be 1 since 0 is not a divisor,
+		// but we expect 0 when both arguments are equal.
 		return 0
 	}
 	a := make([]Word, size)

--- a/num.go
+++ b/num.go
@@ -1469,6 +1469,10 @@ func (z *Nat) eGCD(x []Word, m []Word) ([]Word, []Word) {
 func (x *Nat) Coprime(y *Nat) Choice {
 	maxBits := x.maxAnnounced(y)
 	size := limbCount(maxBits)
+	if size == 0 {
+		// technically the result
+		return 0
+	}
 	a := make([]Word, size)
 	copy(a, x.limbs)
 	b := make([]Word, size)

--- a/num_test.go
+++ b/num_test.go
@@ -1124,6 +1124,24 @@ func TestCoprimeExamples(t *testing.T) {
 	if expected != actual {
 		t.Errorf("%+v != %+v", expected, actual)
 	}
+
+	// check x,y with 0 limbs
+	x = new(Nat)
+	y = new(Nat)
+	expected = Choice(0)
+	actual = x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
+
+	// check x,y=0 with 1 empty limb
+	x.SetUint64(0)
+	y.SetUint64(0)
+	expected = Choice(0)
+	actual = x.Coprime(y)
+	if expected != actual {
+		t.Errorf("%+v != %+v", expected, actual)
+	}
 }
 
 func TestTrueLenExamples(t *testing.T) {


### PR DESCRIPTION
This fixes #43 by branching if `x.maxAnnounced(y) == 0`.